### PR TITLE
Change LANG env variable to an uppercase C

### DIFF
--- a/plugins/check_command
+++ b/plugins/check_command
@@ -89,7 +89,7 @@ if ( defined($match) and !defined($critical) and !defined($warning) ) {
 }
 
 # Run command, capture output
-$ENV{'LANG'} = 'c';
+$ENV{'LANG'} = 'C';
 my $pid = open( my $run, "-|", @command );
 if ($pid) {
     printf( "[debug] Command \"%s\"\n", join( " ", @command ) ) if ($debug);


### PR DESCRIPTION
A lowercase C caused a warning in Perl 5.10, and a subsequent fallback to uppercase C.